### PR TITLE
Feat: env namespacing

### DIFF
--- a/examples/namespaced-worker.e2e.ts
+++ b/examples/namespaced-worker.e2e.ts
@@ -1,0 +1,75 @@
+import { Workflow, Worker } from '../src';
+import sleep from '../src/util/sleep';
+import Hatchet from '../src/sdk';
+
+describe('e2e', () => {
+  let hatchet: Hatchet;
+  let worker: Worker;
+
+  beforeEach(async () => {
+    hatchet = Hatchet.init({
+      namespace: 'dev',
+    });
+    worker = await hatchet.worker('example-worker');
+  });
+
+  afterEach(async () => {
+    await worker.stop();
+    await sleep(2000);
+  });
+
+  it('should pass a simple workflow', async () => {
+    let invoked = 0;
+    const start = new Date();
+
+    const workflow: Workflow = {
+      id: 'simple-e2e-workflow',
+      description: 'test',
+      on: {
+        event: 'user:create',
+      },
+      steps: [
+        {
+          name: 'step1',
+          run: async (ctx) => {
+            console.log('starting step1 with the following input', ctx.workflowInput());
+            console.log(`took ${new Date().getTime() - start.getTime()}ms`);
+            invoked += 1;
+            return { step1: 'step1 results!' };
+          },
+        },
+        {
+          name: 'step2',
+          parents: ['step1'],
+          run: (ctx) => {
+            console.log(`step 1 -> 2 took ${new Date().getTime() - start.getTime()}ms`);
+            console.log('executed step2 after step1 returned ', ctx.stepOutput('step1'));
+            invoked += 1;
+            return { step2: 'step2 results!' };
+          },
+        },
+      ],
+    };
+
+    console.log('registering workflow...');
+    await worker.registerWorkflow(workflow);
+
+    void worker.start();
+
+    console.log('worker started.');
+
+    await sleep(5000);
+
+    console.log('pushing event...');
+
+    await hatchet.event.push('user:create', {
+      test: 'test',
+    });
+
+    await sleep(10000);
+
+    console.log('invoked', invoked);
+
+    expect(invoked).toEqual(2);
+  }, 60000);
+});

--- a/examples/namespaced-worker.e2e.ts
+++ b/examples/namespaced-worker.e2e.ts
@@ -2,7 +2,7 @@ import { Workflow, Worker } from '../src';
 import sleep from '../src/util/sleep';
 import Hatchet from '../src/sdk';
 
-describe('e2e', () => {
+xdescribe('e2e', () => {
   let hatchet: Hatchet;
   let worker: Worker;
 

--- a/examples/namespaced-worker.ts
+++ b/examples/namespaced-worker.ts
@@ -1,0 +1,47 @@
+import Hatchet from '../src/sdk';
+import { Workflow } from '../src/workflow';
+
+const hatchet = Hatchet.init({
+  namespace: 'example-namespace',
+});
+
+const sleep = (ms: number) =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+const workflow: Workflow = {
+  id: 'simple-workflow',
+  description: 'test',
+  on: {
+    event: 'user:create',
+  },
+  steps: [
+    {
+      name: 'step1',
+      run: async (ctx) => {
+        console.log('starting step1 with the following input', ctx.workflowInput());
+        console.log('waiting 5 seconds...');
+        await sleep(5000);
+        console.log('executed step1!');
+        return { step1: 'step1 results!' };
+      },
+    },
+    {
+      name: 'step2',
+      parents: ['step1'],
+      run: (ctx) => {
+        console.log('executed step2 after step1 returned ', ctx.stepOutput('step1'));
+        return { step2: 'step2 results!' };
+      },
+    },
+  ],
+};
+
+async function main() {
+  const worker = await hatchet.worker('example-worker');
+  await worker.registerWorkflow(workflow);
+  worker.start();
+}
+
+main();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hatchet-dev/typescript-sdk",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "description": "Background task orchestration & visibility for developers",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "exec": "npx dotenv -- ts-node -r tsconfig-paths/register --project tsconfig.json",
     "example:event": "npm run exec -- ./examples/example-event.ts",
     "example:event-listen": "npm run exec -- ./examples/example-event-with-results.ts",
+    "worker:namespaced": "npm run exec -- ./examples/namespaced-worker.ts",
     "worker:simple": "npm run exec -- ./examples/simple-worker.ts",
     "manual:trigger": "npm run exec -- ./examples/manual-trigger.ts",
     "worker:dag": "npm run exec -- ./examples/dag-worker.ts",

--- a/src/clients/event/event-client.ts
+++ b/src/clients/event/event-client.ts
@@ -30,15 +30,17 @@ export class EventClient {
   }
 
   push<T>(type: string, input: T) {
+    const namespacedType = this.config.namespace + type;
+
     const req: PushEventRequest = {
-      key: type,
+      key: namespacedType,
       payload: JSON.stringify(input),
       eventTimestamp: new Date(),
     };
 
     try {
       const e = this.client.push(req);
-      this.logger.info(`Event pushed: ${type}`);
+      this.logger.info(`Event pushed: ${namespacedType}`);
       return e;
     } catch (e: any) {
       throw new HatchetError(e.message);

--- a/src/clients/event/event-client.ts
+++ b/src/clients/event/event-client.ts
@@ -30,7 +30,7 @@ export class EventClient {
   }
 
   push<T>(type: string, input: T) {
-    const namespacedType = this.config.namespace + type;
+    const namespacedType = `${this.config.namespace ?? ''}${type}`;
 
     const req: PushEventRequest = {
       key: namespacedType,

--- a/src/clients/hatchet-client/client-config.ts
+++ b/src/clients/hatchet-client/client-config.ts
@@ -16,6 +16,7 @@ export const ClientConfigSchema = z.object({
   api_url: z.string(),
   log_level: z.enum(['OFF', 'DEBUG', 'INFO', 'WARN', 'ERROR']).optional(),
   tenant_id: z.string(),
+  namespace: z.string().optional(),
 });
 
 export type ClientConfig = z.infer<typeof ClientConfigSchema> & {

--- a/src/clients/hatchet-client/hatchet-client.test.ts
+++ b/src/clients/hatchet-client/hatchet-client.test.ts
@@ -17,6 +17,7 @@ describe('Client', () => {
           'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJncnBjX2Jyb2FkY2FzdF9hZGRyZXNzIjoiMTI3LjAuMC4xOjgwODAiLCJzZXJ2ZXJfdXJsIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwIiwic3ViIjoiNzA3ZDA4NTUtODBhYi00ZTFmLWExNTYtZjFjNDU0NmNiZjUyIn0K.abcdef',
         host_port: '127.0.0.1:8080',
         log_level: 'OFF',
+        namespace: '',
         tls_config: {
           cert_file: 'TLS_CERT_FILE',
           key_file: 'TLS_KEY_FILE',
@@ -35,6 +36,7 @@ describe('Client', () => {
         'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJncnBjX2Jyb2FkY2FzdF9hZGRyZXNzIjoiMTI3LjAuMC4xOjgwODAiLCJzZXJ2ZXJfdXJsIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwIiwic3ViIjoiNzA3ZDA4NTUtODBhYi00ZTFmLWExNTYtZjFjNDU0NmNiZjUyIn0K.abcdef',
       host_port: '127.0.0.1:8080',
       log_level: 'OFF',
+      namespace: '',
       api_url: 'http://localhost:8080',
       tenant_id: '707d0855-80ab-4e1f-a156-f1c4546cbf52',
       tls_config: {
@@ -86,6 +88,7 @@ describe('Client', () => {
         'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJncnBjX2Jyb2FkY2FzdF9hZGRyZXNzIjoiMTI3LjAuMC4xOjgwODAiLCJzZXJ2ZXJfdXJsIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwIiwic3ViIjoiNzA3ZDA4NTUtODBhYi00ZTFmLWExNTYtZjFjNDU0NmNiZjUyIn0K.abcdef',
       host_port: 'HOST_PORT_YAML',
       log_level: 'INFO',
+      namespace: '',
       api_url: 'http://localhost:8080',
       tenant_id: '707d0855-80ab-4e1f-a156-f1c4546cbf52',
       tls_config: {

--- a/src/clients/worker/worker.ts
+++ b/src/clients/worker/worker.ts
@@ -40,7 +40,7 @@ export class Worker {
     options: { name: string; handleKill?: boolean; maxRuns?: number }
   ) {
     this.client = client;
-    this.name = options.name;
+    this.name = this.client.config.namespace + options.name;
     this.action_registry = {};
     this.maxRuns = options.maxRuns;
 
@@ -53,7 +53,11 @@ export class Worker {
     this.logger = new Logger(`Worker/${this.name}`, this.client.config.log_level);
   }
 
-  async registerWorkflow(workflow: Workflow) {
+  async registerWorkflow(initWorkflow: Workflow) {
+    const workflow: Workflow = {
+      ...initWorkflow,
+      id: this.client.config.namespace + initWorkflow.id,
+    };
     try {
       const concurrency: WorkflowConcurrencyOpts | undefined = workflow.concurrency?.name
         ? {
@@ -68,7 +72,7 @@ export class Worker {
         name: workflow.id,
         description: workflow.description,
         version: workflow.version || '',
-        eventTriggers: workflow.on.event ? [workflow.on.event] : [],
+        eventTriggers: workflow.on.event ? [this.client.config.namespace + workflow.on.event] : [],
         cronTriggers: workflow.on.cron ? [workflow.on.cron] : [],
         scheduledTriggers: [],
         concurrency,

--- a/src/util/config-loader/config-loader.test.ts
+++ b/src/util/config-loader/config-loader.test.ts
@@ -15,6 +15,7 @@ fdescribe('ConfigLoader', () => {
     expect(config).toEqual({
       host_port: '127.0.0.1:8080',
       log_level: 'INFO',
+      namespace: '',
       api_url: 'http://localhost:8080',
       token:
         'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJncnBjX2Jyb2FkY2FzdF9hZGRyZXNzIjoiMTI3LjAuMC4xOjgwODAiLCJzZXJ2ZXJfdXJsIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwIiwic3ViIjoiNzA3ZDA4NTUtODBhYi00ZTFmLWExNTYtZjFjNDU0NmNiZjUyIn0K.abcdef',
@@ -64,6 +65,7 @@ fdescribe('ConfigLoader', () => {
         'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJncnBjX2Jyb2FkY2FzdF9hZGRyZXNzIjoiMTI3LjAuMC4xOjgwODAiLCJzZXJ2ZXJfdXJsIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwIiwic3ViIjoiNzA3ZDA4NTUtODBhYi00ZTFmLWExNTYtZjFjNDU0NmNiZjUyIn0K.abcdef',
       host_port: 'HOST_PORT_YAML',
       log_level: 'INFO',
+      namespace: '',
       api_url: 'http://localhost:8080',
       tenant_id: '707d0855-80ab-4e1f-a156-f1c4546cbf52',
       tls_config: {

--- a/src/util/config-loader/config-loader.ts
+++ b/src/util/config-loader/config-loader.ts
@@ -16,7 +16,8 @@ type EnvVars =
   | 'HATCHET_CLIENT_TLS_KEY_FILE'
   | 'HATCHET_CLIENT_TLS_ROOT_CA_FILE'
   | 'HATCHET_CLIENT_TLS_SERVER_NAME'
-  | 'HATCHET_CLIENT_LOG_LEVEL';
+  | 'HATCHET_CLIENT_LOG_LEVEL'
+  | 'HATCHET_CLIENT_NAMESPACE';
 
 type TLSStrategy = 'tls' | 'mtls';
 
@@ -41,6 +42,7 @@ export class ConfigLoader {
       key_file: yaml?.tls_config?.key_file ?? this.env('HATCHET_CLIENT_TLS_KEY_FILE')!,
       ca_file: yaml?.tls_config?.ca_file ?? this.env('HATCHET_CLIENT_TLS_ROOT_CA_FILE')!,
       server_name: yaml?.tls_config?.server_name ?? this.env('HATCHET_CLIENT_TLS_SERVER_NAME')!,
+      namespace: yaml?.namespace ?? this.env('HATCHET_CLIENT_NAMESPACE'),
     };
 
     const token = override?.token ?? yaml?.token ?? this.env('HATCHET_CLIENT_TOKEN');

--- a/src/util/config-loader/config-loader.ts
+++ b/src/util/config-loader/config-loader.ts
@@ -42,7 +42,6 @@ export class ConfigLoader {
       key_file: yaml?.tls_config?.key_file ?? this.env('HATCHET_CLIENT_TLS_KEY_FILE')!,
       ca_file: yaml?.tls_config?.ca_file ?? this.env('HATCHET_CLIENT_TLS_ROOT_CA_FILE')!,
       server_name: yaml?.tls_config?.server_name ?? this.env('HATCHET_CLIENT_TLS_SERVER_NAME')!,
-      namespace: yaml?.namespace ?? this.env('HATCHET_CLIENT_NAMESPACE'),
     };
 
     const token = override?.token ?? yaml?.token ?? this.env('HATCHET_CLIENT_TOKEN');
@@ -88,6 +87,7 @@ export class ConfigLoader {
         (this.env('HATCHET_CLIENT_LOG_LEVEL') as LogLevel) ??
         'INFO',
       tenant_id: tenantId,
+      namespace: override?.namespace ?? yaml?.namespace ?? this.env('HATCHET_CLIENT_NAMESPACE'),
     };
   }
 

--- a/src/util/config-loader/config-loader.ts
+++ b/src/util/config-loader/config-loader.ts
@@ -76,6 +76,9 @@ export class ConfigLoader {
       apiUrl = override?.api_url ?? yaml?.api_url ?? this.env('HATCHET_CLIENT_API_URL');
     }
 
+    const namespace =
+      override?.namespace ?? yaml?.namespace ?? this.env('HATCHET_CLIENT_NAMESPACE');
+
     return {
       token: override?.token ?? yaml?.token ?? this.env('HATCHET_CLIENT_TOKEN'),
       host_port: grpcBroadcastAddress,
@@ -87,7 +90,7 @@ export class ConfigLoader {
         (this.env('HATCHET_CLIENT_LOG_LEVEL') as LogLevel) ??
         'INFO',
       tenant_id: tenantId,
-      namespace: override?.namespace ?? yaml?.namespace ?? this.env('HATCHET_CLIENT_NAMESPACE'),
+      namespace: namespace ? `${namespace}_` : undefined,
     };
   }
 

--- a/src/util/config-loader/config-loader.ts
+++ b/src/util/config-loader/config-loader.ts
@@ -90,7 +90,7 @@ export class ConfigLoader {
         (this.env('HATCHET_CLIENT_LOG_LEVEL') as LogLevel) ??
         'INFO',
       tenant_id: tenantId,
-      namespace: namespace ? `${namespace}_` : undefined,
+      namespace: namespace ? `${namespace}_` : '',
     };
   }
 


### PR DESCRIPTION
Problem: multiple hatchet workers will pick up all events dispatched in a tenant. 

Solve: we can simply namespace all resources handled by that instance.
```
const hatchet = Hatchet.init({
  namespace: 'dev',
});
```
