### PR TITLE
Change reporting of step error to default to message property

### DIFF
--- a/src/clients/worker/worker.ts
+++ b/src/clients/worker/worker.ts
@@ -167,7 +167,7 @@ export class Worker {
           const event = this.getStepActionEvent(
             action,
             StepActionEventType.STEP_EVENT_TYPE_FAILED,
-            error
+            error?.message || error
           );
           this.client.dispatcher.sendStepActionEvent(event);
           // delete the run from the futures


### PR DESCRIPTION
# Current Implementation (before pull request)
When throwing a normal `Error` object from inside a step's run, the error message passed gets logged in the worker's console but the message given to the backend is an empty object `{}`

![image](https://github.com/hatchet-dev/hatchet-typescript/assets/46821216/a4ffd9ad-e2d4-42e5-a8b6-6bcbc050f33b)
![image](https://github.com/hatchet-dev/hatchet-typescript/assets/46821216/67f5338d-85a9-46fc-a571-1c877154e0fa)

# This Implementation
I've replaced the message sent to the backend to include the message property of the Error object, instead of using the main object. If the message property isn't specified (may that be from a custom exception or otherwise), it will default to the object passed.

It appears that down the pipeline, instead of casting the error to a string, a JSON.stringify is used which turns Error objects into `{}`, destroying all the error message information.

# Workarounds
Writing a custom Error class and overwriting `#toJSON` to return a string (or could be any object) that will be passed to the hatchet backend
![image](https://github.com/hatchet-dev/hatchet-typescript/assets/46821216/4aa5692f-a25f-43ca-ba46-0c505d6e4f93)
![image](https://github.com/hatchet-dev/hatchet-typescript/assets/46821216/766043a6-d4c3-4dd8-b267-551bb46d9e27)
![image](https://github.com/hatchet-dev/hatchet-typescript/assets/46821216/a4fc6926-6623-4abb-b0bd-a9d629cef03b)
