### PR TITLE
fix: send group key action event properly

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hatchet-dev/typescript-sdk",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Background task orchestration & visibility for developers",
   "types": "dist/index.d.ts",
   "files": [
@@ -34,10 +34,8 @@
     "example:event": "npm run exec -- ./examples/example-event.ts",
     "example:event-listen": "npm run exec -- ./examples/example-event-with-results.ts",
     "worker:namespaced": "npm run exec -- ./examples/namespaced-worker.ts",
-
     "worker:rate": "npm run exec -- ./examples/rate-limit/worker.ts",
     "example:rate": "npm run exec -- ./examples/rate-limit/events.ts",
-
     "worker:fanout": "npm run exec -- ./examples/fanout-worker.ts",
     "worker:simple": "npm run exec -- ./examples/simple-worker.ts",
     "manual:trigger": "npm run exec -- ./examples/manual-trigger.ts",

--- a/src/clients/worker/worker.ts
+++ b/src/clients/worker/worker.ts
@@ -262,8 +262,11 @@ export class Worker {
       this.futures[action.getGroupKeyRunId] = future;
 
       // Send the action event to the dispatcher
-      const event = this.getStepActionEvent(action, StepActionEventType.STEP_EVENT_TYPE_STARTED);
-      this.client.dispatcher.sendStepActionEvent(event);
+      const event = this.getGroupKeyActionEvent(
+        action,
+        GroupKeyActionEventType.GROUP_KEY_EVENT_TYPE_STARTED
+      );
+      this.client.dispatcher.sendGroupKeyActionEvent(event);
     } catch (e: any) {
       this.logger.error(`Could not send action event: ${e.message}`);
     }


### PR DESCRIPTION
We were sending an incorrect `stepRunActionEvent` for concurrency group keys here. 