### PR TITLE
fix: lowercase namespace config

### DIFF
--- a/src/util/config-loader/config-loader.ts
+++ b/src/util/config-loader/config-loader.ts
@@ -90,7 +90,7 @@ export class ConfigLoader {
         (this.env('HATCHET_CLIENT_LOG_LEVEL') as LogLevel) ??
         'INFO',
       tenant_id: tenantId,
-      namespace: namespace ? `${namespace}_` : '',
+      namespace: namespace ? `${namespace}_`.toLowerCase() : '',
     };
   }
 


### PR DESCRIPTION
Namespaces should be lowercase across all uses in the sdk