### PR TITLE
fix: catch all async errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hatchet-dev/typescript-sdk",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "description": "Background task orchestration & visibility for developers",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/clients/dispatcher/dispatcher-client.ts
+++ b/src/clients/dispatcher/dispatcher-client.ts
@@ -43,7 +43,7 @@ export class DispatcherClient {
 
   async sendStepActionEvent(in_: StepActionEvent) {
     try {
-      return retrier(async () => this.client.sendStepActionEvent(in_), this.logger);
+      return await retrier(async () => this.client.sendStepActionEvent(in_), this.logger);
     } catch (e: any) {
       throw new HatchetError(e.message);
     }
@@ -51,17 +51,15 @@ export class DispatcherClient {
 
   async sendGroupKeyActionEvent(in_: GroupKeyActionEvent) {
     try {
-      return retrier(async () => this.client.sendGroupKeyActionEvent(in_), this.logger);
+      return await retrier(async () => this.client.sendGroupKeyActionEvent(in_), this.logger);
     } catch (e: any) {
       throw new HatchetError(e.message);
     }
   }
 
   async putOverridesData(in_: DeepPartial<OverridesData>) {
-    try {
-      return retrier(async () => this.client.putOverridesData(in_), this.logger);
-    } catch (e: any) {
-      throw new HatchetError(e.message);
-    }
+    return retrier(async () => this.client.putOverridesData(in_), this.logger).catch((e) => {
+      this.logger.warn(`Could not put overrides data: ${e.message}`);
+    });
   }
 }

--- a/src/clients/event/event-client.ts
+++ b/src/clients/event/event-client.ts
@@ -47,7 +47,7 @@ export class EventClient {
     }
   }
 
-  async putLog(stepRunId: string, log: string, level?: LogLevel) {
+  putLog(stepRunId: string, log: string, level?: LogLevel) {
     const createdAt = new Date();
 
     retrier(

--- a/src/clients/event/event-client.ts
+++ b/src/clients/event/event-client.ts
@@ -47,24 +47,22 @@ export class EventClient {
     }
   }
 
-  putLog(stepRunId: string, log: string, level?: LogLevel) {
+  async putLog(stepRunId: string, log: string, level?: LogLevel) {
     const createdAt = new Date();
 
-    try {
-      retrier(
-        async () =>
-          this.client.putLog({
-            stepRunId,
-            createdAt,
-            message: log,
-            level: level || LogLevel.INFO,
-          }),
-        this.logger
-      );
-    } catch (e: any) {
+    retrier(
+      async () =>
+        this.client.putLog({
+          stepRunId,
+          createdAt,
+          message: log,
+          level: level || LogLevel.INFO,
+        }),
+      this.logger
+    ).catch((e: any) => {
       // log a warning, but this is not a fatal error
       this.logger.warn(`Could not put log: ${e.message}`);
-    }
+    });
   }
 
   putStream(stepRunId: string, data: string | Uint8Array) {
@@ -79,19 +77,17 @@ export class EventClient {
       throw new Error('Invalid data type. Expected string or Uint8Array.');
     }
 
-    try {
-      retrier(
-        async () =>
-          this.client.putStreamEvent({
-            stepRunId,
-            createdAt,
-            message: dataBytes,
-          }),
-        this.logger
-      );
-    } catch (e: any) {
+    retrier(
+      async () =>
+        this.client.putStreamEvent({
+          stepRunId,
+          createdAt,
+          message: dataBytes,
+        }),
+      this.logger
+    ).catch((e: any) => {
       // log a warning, but this is not a fatal error
       this.logger.warn(`Could not put log: ${e.message}`);
-    }
+    });
   }
 }

--- a/src/clients/worker/worker.ts
+++ b/src/clients/worker/worker.ts
@@ -160,7 +160,9 @@ export class Worker {
             StepActionEventType.STEP_EVENT_TYPE_COMPLETED,
             result
           );
-          this.client.dispatcher.sendStepActionEvent(event);
+          this.client.dispatcher.sendStepActionEvent(event).catch((e) => {
+            this.logger.error(`Could not send action event: ${e.message}`);
+          });
 
           // delete the run from the futures
           delete this.futures[action.stepRunId];
@@ -169,7 +171,7 @@ export class Worker {
         }
       };
 
-      const failure = (error: any) => {
+      const failure = async (error: any) => {
         this.logger.error(`Step run ${action.stepRunId} failed: ${error.message}`);
 
         try {
@@ -179,7 +181,9 @@ export class Worker {
             StepActionEventType.STEP_EVENT_TYPE_FAILED,
             error?.message || error
           );
-          this.client.dispatcher.sendStepActionEvent(event);
+          this.client.dispatcher.sendStepActionEvent(event).catch((e) => {
+            this.logger.error(`Could not send action event: ${e.message}`);
+          });
           // delete the run from the futures
           delete this.futures[action.stepRunId];
         } catch (e: any) {
@@ -192,7 +196,9 @@ export class Worker {
 
       // Send the action event to the dispatcher
       const event = this.getStepActionEvent(action, StepActionEventType.STEP_EVENT_TYPE_STARTED);
-      this.client.dispatcher.sendStepActionEvent(event);
+      this.client.dispatcher.sendStepActionEvent(event).catch((e) => {
+        this.logger.error(`Could not send action event: ${e.message}`);
+      });
     } catch (e: any) {
       this.logger.error(`Could not send action event: ${e.message}`);
     }
@@ -231,7 +237,9 @@ export class Worker {
             GroupKeyActionEventType.GROUP_KEY_EVENT_TYPE_COMPLETED,
             result
           );
-          this.client.dispatcher.sendGroupKeyActionEvent(event);
+          this.client.dispatcher.sendGroupKeyActionEvent(event).catch((e) => {
+            this.logger.error(`Could not send action event: ${e.message}`);
+          });
 
           // delete the run from the futures
           delete this.futures[key];
@@ -250,7 +258,9 @@ export class Worker {
             GroupKeyActionEventType.GROUP_KEY_EVENT_TYPE_FAILED,
             error
           );
-          this.client.dispatcher.sendGroupKeyActionEvent(event);
+          this.client.dispatcher.sendGroupKeyActionEvent(event).catch((e) => {
+            this.logger.error(`Could not send action event: ${e.message}`);
+          });
           // delete the run from the futures
           delete this.futures[key];
         } catch (e: any) {
@@ -266,7 +276,9 @@ export class Worker {
         action,
         GroupKeyActionEventType.GROUP_KEY_EVENT_TYPE_STARTED
       );
-      this.client.dispatcher.sendGroupKeyActionEvent(event);
+      this.client.dispatcher.sendGroupKeyActionEvent(event).catch((e) => {
+        this.logger.error(`Could not send action event: ${e.message}`);
+      });
     } catch (e: any) {
       this.logger.error(`Could not send action event: ${e.message}`);
     }

--- a/src/clients/worker/worker.ts
+++ b/src/clients/worker/worker.ts
@@ -171,7 +171,7 @@ export class Worker {
         }
       };
 
-      const failure = async (error: any) => {
+      const failure = (error: any) => {
         this.logger.error(`Step run ${action.stepRunId} failed: ${error.message}`);
 
         try {

--- a/src/util/retrier.ts
+++ b/src/util/retrier.ts
@@ -1,7 +1,7 @@
 import { Logger } from './logger';
 import sleep from './sleep';
 
-const DEFAULT_RETRY_INTERVAL = 5;
+const DEFAULT_RETRY_INTERVAL = 5; // seconds
 const DEFAULT_RETRY_COUNT = 5;
 
 export async function retrier<T>(


### PR DESCRIPTION
Not all async methods were catching their errors due to not using `await` inside of the `try` block, leading to errors being thrown asynchronously after returning from the method. These errors were then unhandled, causing the worker to restart. 