### PR TITLE
fix: remove reference to heartbeat

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hatchet-dev/typescript-sdk",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Background task orchestration & visibility for developers",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/clients/dispatcher/action-listener.ts
+++ b/src/clients/dispatcher/action-listener.ts
@@ -124,6 +124,7 @@ export class ActionListener {
       } catch (e: any) {
         if (e.code === Status.UNIMPLEMENTED) {
           // break out of interval
+          this.logger.error('Heartbeat not implemented, closing heartbeat');
           this.closeHeartbeat();
           return;
         }
@@ -140,6 +141,7 @@ export class ActionListener {
   closeHeartbeat() {
     if (this.heartbeatInterval) {
       clearInterval(this.heartbeatInterval);
+      this.heartbeatInterval = null;
     }
   }
 


### PR DESCRIPTION
Although we are clearing the heartbeat interval via `clearInterval`, we are not setting `this.heartbeatInterval = null;`, which means that when we are calling `heartbeat()` on retries we are not actually starting a heartbeat. This means that when a retry fails with `UNAVAILABLE`, the heartbeat can stop on a running worker. 