### PR TITLE
proof of security

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
-    if: ${{ github.actor == 'dependabot[bot]' }}
+#    if: ${{ github.actor == 'dependabot[bot]' }}
     permissions:
       pull-requests: write
       issues: write
@@ -19,7 +19,7 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: "Enable auto-squash"
-        if: steps.metadata.outputs.package-ecosystem == 'submodules'
+#        if: steps.metadata.outputs.package-ecosystem == 'submodules'
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
This is a proof of the GitHub action auto-merge workflow being secure as it uses `pull_request_target`:

<img width="832" alt="Screenshot 2024-05-21 at 22 19 55" src="https://github.com/hatchet-dev/hatchet-typescript/assets/5013932/f3695ab1-b7c9-4ecc-bcb8-102cc928f431">
<img width="586" alt="Screenshot 2024-05-21 at 22 20 22" src="https://github.com/hatchet-dev/hatchet-typescript/assets/5013932/9184bef8-be4e-4a61-9779-326745c3a30a">
