### PR TITLE
chore(package): use dist dir for publish and entrypoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,13 +3,8 @@
   "version": "0.12.0",
   "description": "Background task orchestration & visibility for developers",
   "types": "dist/index.d.ts",
-  "files": [
-    "*",
-    "!**/*.test.js",
-    "!**/*.test.d.ts",
-    "!**/*.e2e.js",
-    "!**/*.e2e.d.ts"
-  ],
+  "main": "dist/index.js",
+  "files": ["dist/**/*"],
   "repository": {
     "type": "git",
     "url": "https://github.com/hatchet-dev/hatchet-typescript.git"
@@ -54,7 +49,7 @@
     "worker:logger": "npm run exec -- ./src/examples/logger.ts",
     "api": "npm run exec -- ./src/examples/api.ts",
     "prepublish": "cp package.json dist/package.json;",
-    "publish:ci": "rm -rf ./dist && npm run tsc:build && npm run prepublish && cd dist && npm publish --access public --no-git-checks",
+    "publish:ci": "rm -rf ./dist && npm run tsc:build && npm run prepublish && npm publish --access public --no-git-checks",
     "generate-docs": "typedoc"
   },
   "keywords": [],


### PR DESCRIPTION
Change the behaviour of the dist directory:
- set dist/index.js as entrypoint
- set `files` to only include the dist directory on publish

This makes development easier because the entrypoint is the same when using npm/pnpm link.

The only downside is that imports for the end user would include the dist directory (e.g. `@hatchet-dev/typescript-sdk/dist/foo/bar`), but everything should be imported from the root package anyway.