### PR TITLE
fix: namespace should propagate to child workflows/runs, fix step types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hatchet-dev/typescript-sdk",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Background task orchestration & visibility for developers",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/clients/admin/admin-client.ts
+++ b/src/clients/admin/admin-client.ts
@@ -114,7 +114,7 @@ export class AdminClient {
       const inputStr = JSON.stringify(input);
 
       const resp = await this.client.triggerWorkflow({
-        name: workflowName,
+        name,
         input: inputStr,
         ...options,
         additionalMetadata: options?.additionalMetadata

--- a/src/clients/admin/admin-client.ts
+++ b/src/clients/admin/admin-client.ts
@@ -109,6 +109,8 @@ export class AdminClient {
     }
   ) {
     try {
+      const name = this.config.namespace + workflowName;
+
       const inputStr = JSON.stringify(input);
 
       const resp = await this.client.triggerWorkflow({

--- a/src/clients/admin/admin-client.ts
+++ b/src/clients/admin/admin-client.ts
@@ -109,12 +109,14 @@ export class AdminClient {
     }
   ) {
     try {
-      const name = this.config.namespace + workflowName;
+      if (this.config.namespace && !workflowName.startsWith(this.config.namespace)) {
+        workflowName = this.config.namespace + workflowName;
+      }
 
       const inputStr = JSON.stringify(input);
 
       const resp = await this.client.triggerWorkflow({
-        name,
+        name: workflowName,
         input: inputStr,
         ...options,
         additionalMetadata: options?.additionalMetadata

--- a/src/step.ts
+++ b/src/step.ts
@@ -208,7 +208,9 @@ export class Context<T, K> {
   ): ChildWorkflowRef<P> {
     const { workflowRunId, stepRunId } = this.action;
 
-    const childWorkflowRunIdPromise = this.client.admin.run_workflow(workflowName, input, {
+    const name = this.client.config.namespace + workflowName;
+
+    const childWorkflowRunIdPromise = this.client.admin.run_workflow(name, input, {
       parentId: workflowRunId,
       parentStepRunId: stepRunId,
       childKey: key,
@@ -221,7 +223,7 @@ export class Context<T, K> {
   }
 }
 
-export type StepRunFunction<T, K> = (ctx: Context<T, K>) => Promise<NextStep> | NextStep | void;
+export type StepRunFunction<T, K> = (ctx: Context<T, K>) => Promise<NextStep | void> | NextStep | void;
 
 export interface CreateStep<T, K> extends z.infer<typeof CreateStepSchema> {
   run: StepRunFunction<T, K>;


### PR DESCRIPTION
- Adds namespace propagation to `spawnWorkflow` and `run_workflow`
- Fixes step types so they can return `Promise<void>`