### PR TITLE
fix: make `on` block optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hatchet-dev/typescript-sdk",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Background task orchestration & visibility for developers",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/clients/worker/worker.ts
+++ b/src/clients/worker/worker.ts
@@ -101,8 +101,11 @@ export class Worker {
         name: workflow.id,
         description: workflow.description,
         version: workflow.version || '',
-        eventTriggers: workflow.on.event ? [this.client.config.namespace + workflow.on.event] : [],
-        cronTriggers: workflow.on.cron ? [workflow.on.cron] : [],
+        eventTriggers:
+          workflow.on && workflow.on.event
+            ? [this.client.config.namespace + workflow.on.event]
+            : [],
+        cronTriggers: workflow.on && workflow.on.cron ? [workflow.on.cron] : [],
         scheduledTriggers: [],
         concurrency,
         scheduleTimeout: workflow.scheduleTimeout,

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -13,7 +13,7 @@ const EventConfigSchema = z.object({
   event: z.string(),
 });
 
-const OnConfigSchema = z.union([CronConfigSchema, EventConfigSchema]);
+const OnConfigSchema = z.union([CronConfigSchema, EventConfigSchema]).optional();
 
 const StepsSchema = z.array(CreateStepSchema);
 


### PR DESCRIPTION
It shouldn't be required that workflows set the `on` block, especially since they can be triggered as child workflows or via `runWorkflow`. 