### PR TITLE
fix: make second context type param optional

### DIFF
--- a/src/step.ts
+++ b/src/step.ts
@@ -89,7 +89,7 @@ class ChildWorkflowRef<T> {
   }
 }
 
-export class Context<T, K> {
+export class Context<T, K = {}> {
   data: ContextData<T, K>;
   input: T;
   controller = new AbortController();


### PR DESCRIPTION
No point in making users set the `UserData` type since it's very rarely used. 