### PR TITLE
refactor: return `WorkflowRunRef` from methods which create or get workflow runs

### DIFF
--- a/examples/fanout-worker.e2e.ts
+++ b/examples/fanout-worker.e2e.ts
@@ -27,9 +27,6 @@ xdescribe('fanout-e2e', () => {
     const childWorkflow: Workflow = {
       id: 'child-workflow',
       description: 'simple example for spawning child workflows',
-      on: {
-        event: 'fanout:create',
-      },
       steps: [
         {
           name: 'child-work',
@@ -57,7 +54,7 @@ xdescribe('fanout-e2e', () => {
 
     await sleep(5000);
 
-    console.log('pushing event...');
+    console.log('running workflow...');
 
     await hatchet.admin.runWorkflow('parent-workflow', { input: 'parent-input' });
 

--- a/examples/fanout-worker.e2e.ts
+++ b/examples/fanout-worker.e2e.ts
@@ -9,17 +9,14 @@ xdescribe('fanout-e2e', () => {
     const parentWorkflow: Workflow = {
       id: 'parent-workflow',
       description: 'simple example for spawning child workflows',
-      on: {
-        event: 'fanout:create',
-      },
       steps: [
         {
           name: 'parent-spawn',
           timeout: '10s',
           run: async (ctx) => {
-            const res = await ctx
-              .spawnWorkflow<string>('child-workflow', { input: 'child-input' })
-              .result();
+            const ref = ctx.spawnWorkflow<string>('child-workflow', { input: 'child-input' });
+
+            const res = await ref.result();
             console.log('spawned workflow result:', res);
             invoked += 1;
             return { spawned: [res] };

--- a/examples/fanout-worker.e2e.ts
+++ b/examples/fanout-worker.e2e.ts
@@ -14,7 +14,7 @@ xdescribe('fanout-e2e', () => {
           name: 'parent-spawn',
           timeout: '10s',
           run: async (ctx) => {
-            const ref = ctx.spawnWorkflow<string>('child-workflow', { input: 'child-input' });
+            const ref = ctx.spawnWorkflow('child-workflow', { input: 'child-input' });
 
             const res = await ref.result();
             console.log('spawned workflow result:', res);

--- a/examples/fanout-worker.ts
+++ b/examples/fanout-worker.ts
@@ -19,14 +19,13 @@ const parentWorkflow: Workflow = {
       name: 'parent-spawn',
       timeout: '10s',
       run: async (ctx) => {
-
         const promises = Array.from({ length: 7 }, (_, i) =>
           ctx.spawnWorkflow<string>('child-workflow', { input: `child-input-${i}` }).result()
         );
 
         const results = await Promise.all(promises);
         console.log('spawned workflow results:', results);
-        console.log('number of spawned workflows:', results.length)
+        console.log('number of spawned workflows:', results.length);
         return { spawned: results };
       },
     },

--- a/examples/fanout-worker.ts
+++ b/examples/fanout-worker.ts
@@ -8,6 +8,16 @@ const sleep = (ms: number) =>
     setTimeout(resolve, ms);
   });
 
+type Input = {
+  input: string;
+};
+
+type Output = {
+  'child-work': {
+    'child-output': string;
+  };
+};
+
 const parentWorkflow: Workflow = {
   id: 'parent-workflow',
   description: 'simple example for spawning child workflows',
@@ -20,7 +30,7 @@ const parentWorkflow: Workflow = {
       timeout: '10s',
       run: async (ctx) => {
         const promises = Array.from({ length: 7 }, (_, i) =>
-          ctx.spawnWorkflow<string>('child-workflow', { input: `child-input-${i}` }).result()
+          ctx.spawnWorkflow<Input, Output>('child-workflow', { input: `child-input-${i}` }).result()
         );
 
         const results = await Promise.all(promises);

--- a/examples/manual-trigger.ts
+++ b/examples/manual-trigger.ts
@@ -3,8 +3,8 @@ import Hatchet from '../src/sdk';
 const hatchet = Hatchet.init();
 
 async function main() {
-  const workflowRunId = await hatchet.admin.runWorkflow('simple-workflow', {});
-  const stream = await hatchet.listener.stream(workflowRunId);
+  const workflowRun = hatchet.admin.runWorkflow('simple-workflow', {});
+  const stream = await workflowRun.stream();
 
   for await (const event of stream) {
     console.log('event received', event);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hatchet-dev/typescript-sdk",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "description": "Background task orchestration & visibility for developers",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/clients/admin/admin-client.test.ts
+++ b/src/clients/admin/admin-client.test.ts
@@ -1,53 +1,60 @@
 import { CreateWorkflowVersionOpts, WorkflowVersion } from '@hatchet/protoc/workflows';
 import { AdminClient } from './admin-client';
 import { mockChannel, mockFactory } from '../hatchet-client/hatchet-client.test';
+import { ListenerClient } from '../listener/listener-client';
 
 describe('AdminClient', () => {
   let client: AdminClient;
 
   it('should create a client', () => {
-    const x = new AdminClient(
-      {
-        token:
-          'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJncnBjX2Jyb2FkY2FzdF9hZGRyZXNzIjoiMTI3LjAuMC4xOjgwODAiLCJzZXJ2ZXJfdXJsIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwIiwic3ViIjoiNzA3ZDA4NTUtODBhYi00ZTFmLWExNTYtZjFjNDU0NmNiZjUyIn0K.abcdef',
-        host_port: 'HOST_PORT',
-        tls_config: {
-          cert_file: 'TLS_CERT_FILE',
-          key_file: 'TLS_KEY_FILE',
-          ca_file: 'TLS_ROOT_CA_FILE',
-          server_name: 'TLS_SERVER_NAME',
-        },
-        api_url: 'API_URL',
-        tenant_id: 'tenantId',
+    const config = {
+      token:
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJncnBjX2Jyb2FkY2FzdF9hZGRyZXNzIjoiMTI3LjAuMC4xOjgwODAiLCJzZXJ2ZXJfdXJsIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwIiwic3ViIjoiNzA3ZDA4NTUtODBhYi00ZTFmLWExNTYtZjFjNDU0NmNiZjUyIn0K.abcdef',
+      host_port: 'HOST_PORT',
+      tls_config: {
+        cert_file: 'TLS_CERT_FILE',
+        key_file: 'TLS_KEY_FILE',
+        ca_file: 'TLS_ROOT_CA_FILE',
+        server_name: 'TLS_SERVER_NAME',
       },
+      api_url: 'API_URL',
+      tenant_id: 'tenantId',
+    };
+
+    const x = new AdminClient(
+      config,
       mockChannel,
       mockFactory,
       {} as any,
-      'tenantId'
+      'tenantId',
+      new ListenerClient(config, mockChannel, mockFactory, {} as any)
     );
 
     expect(x).toBeDefined();
   });
 
   beforeEach(() => {
-    client = new AdminClient(
-      {
-        token:
-          'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJncnBjX2Jyb2FkY2FzdF9hZGRyZXNzIjoiMTI3LjAuMC4xOjgwODAiLCJzZXJ2ZXJfdXJsIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwIiwic3ViIjoiNzA3ZDA4NTUtODBhYi00ZTFmLWExNTYtZjFjNDU0NmNiZjUyIn0K.abcdef',
-        host_port: 'HOST_PORT',
-        tls_config: {
-          cert_file: 'TLS_CERT_FILE',
-          key_file: 'TLS_KEY_FILE',
-          ca_file: 'TLS_ROOT_CA_FILE',
-          server_name: 'TLS_SERVER_NAME',
-        },
-        api_url: 'API_URL',
-        tenant_id: 'tenantId',
+    const config = {
+      token:
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJncnBjX2Jyb2FkY2FzdF9hZGRyZXNzIjoiMTI3LjAuMC4xOjgwODAiLCJzZXJ2ZXJfdXJsIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwIiwic3ViIjoiNzA3ZDA4NTUtODBhYi00ZTFmLWExNTYtZjFjNDU0NmNiZjUyIn0K.abcdef',
+      host_port: 'HOST_PORT',
+      tls_config: {
+        cert_file: 'TLS_CERT_FILE',
+        key_file: 'TLS_KEY_FILE',
+        ca_file: 'TLS_ROOT_CA_FILE',
+        server_name: 'TLS_SERVER_NAME',
       },
+      api_url: 'API_URL',
+      tenant_id: 'tenantId',
+    };
+
+    client = new AdminClient(
+      config,
       mockChannel,
       mockFactory,
       {} as any,
-      'tenantId'
+      'tenantId',
+      new ListenerClient(config, mockChannel, mockFactory, {} as any)
     );
   });
 

--- a/src/clients/admin/admin-client.ts
+++ b/src/clients/admin/admin-client.ts
@@ -134,9 +134,9 @@ export class AdminClient {
    * @param options an object containing the options to run the workflow
    * @returns the ID of the new workflow run
    */
-  runWorkflow<T = object, P = object>(
+  runWorkflow<Q = object, P = object>(
     workflowName: string,
-    input: T,
+    input: Q,
     options?: {
       parentId?: string | undefined;
       parentStepRunId?: string | undefined;

--- a/src/clients/admin/admin-client.ts
+++ b/src/clients/admin/admin-client.ts
@@ -134,7 +134,7 @@ export class AdminClient {
    * @param options an object containing the options to run the workflow
    * @returns the ID of the new workflow run
    */
-  runWorkflow<P = object, T = object>(
+  runWorkflow<T = object, P = object>(
     workflowName: string,
     input: T,
     options?: {

--- a/src/clients/admin/admin-client.ts
+++ b/src/clients/admin/admin-client.ts
@@ -279,23 +279,26 @@ export class AdminClient {
    */
   async schedule_workflow(
     name: string,
+    input: object,
     options?: {
       schedules?: Date[];
     }
   ) {
-    return this.scheduleWorkflow(name, options);
+    return this.scheduleWorkflow(name, input, options);
   }
 
   /**
    * Schedule a workflow to run at a specific time or times.
    * @param name the name of the workflow to schedule
+   * @param input an object containing the input to the workflow
    * @param options an object containing the schedules to set
    */
-  scheduleWorkflow(name: string, options?: { schedules?: Date[] }) {
+  scheduleWorkflow(name: string, input: object, options?: { schedules?: Date[] }) {
     try {
       this.client.scheduleWorkflow({
         name,
         schedules: options?.schedules,
+        input: JSON.stringify(input),
       });
     } catch (e: any) {
       throw new HatchetError(e.message);

--- a/src/clients/admin/admin-client.ts
+++ b/src/clients/admin/admin-client.ts
@@ -9,9 +9,11 @@ import HatchetError from '@util/errors/hatchet-error';
 import { ClientConfig } from '@clients/hatchet-client/client-config';
 import { Logger } from '@hatchet/util/logger';
 import { retrier } from '@hatchet/util/retrier';
+import WorkflowRunRef from '@hatchet/util/workflow-run-ref';
 
 import { Api } from '../rest';
 import { WorkflowRunStatus, WorkflowRunStatusList } from '../rest/generated/data-contracts';
+import { ListenerClient } from '../listener/listener-client';
 
 type WorkflowMetricsQuery = {
   workflowId?: string;
@@ -42,19 +44,22 @@ export class AdminClient {
   api: Api;
   tenantId: string;
   logger: Logger;
+  listenerClient: ListenerClient;
 
   constructor(
     config: ClientConfig,
     channel: Channel,
     factory: ClientFactory,
     api: Api,
-    tenantId: string
+    tenantId: string,
+    listenerClient: ListenerClient
   ) {
     this.config = config;
     this.client = factory.create(WorkflowServiceDefinition, channel);
     this.api = api;
     this.tenantId = tenantId;
     this.logger = new Logger(`Admin`, config.log_level);
+    this.listenerClient = listenerClient;
   }
 
   /**
@@ -129,7 +134,7 @@ export class AdminClient {
    * @param options an object containing the options to run the workflow
    * @returns the ID of the new workflow run
    */
-  async runWorkflow<T = object>(
+  runWorkflow<P = object, T = object>(
     workflowName: string,
     input: T,
     options?: {
@@ -149,7 +154,7 @@ export class AdminClient {
 
       const inputStr = JSON.stringify(input);
 
-      const resp = await this.client.triggerWorkflow({
+      const resp = this.client.triggerWorkflow({
         name: computedName,
         input: inputStr,
         ...options,
@@ -158,7 +163,7 @@ export class AdminClient {
           : undefined,
       });
 
-      return resp.workflowRunId;
+      return new WorkflowRunRef<P>(resp, this.listenerClient, options?.parentId);
     } catch (e: any) {
       throw new HatchetError(e.message);
     }
@@ -231,8 +236,7 @@ export class AdminClient {
    * @returns the workflow run
    */
   async getWorkflowRun(workflowRunId: string) {
-    const res = await this.api.workflowRunGet(this.tenantId, workflowRunId);
-    return res.data;
+    return new WorkflowRunRef(workflowRunId, this.listenerClient);
   }
 
   /**

--- a/src/clients/admin/admin-client.ts
+++ b/src/clients/admin/admin-client.ts
@@ -277,28 +277,28 @@ export class AdminClient {
   /**
    * @deprecated use scheduleWorkflow instead
    */
-  async schedule_workflow(
-    name: string,
-    input: object,
-    options?: {
-      schedules?: Date[];
-    }
-  ) {
-    return this.scheduleWorkflow(name, input, options);
+  async schedule_workflow(name: string, options?: { schedules?: Date[]; input?: object }) {
+    return this.scheduleWorkflow(name, options);
   }
 
   /**
    * Schedule a workflow to run at a specific time or times.
    * @param name the name of the workflow to schedule
-   * @param input an object containing the input to the workflow
    * @param options an object containing the schedules to set
+   * @param input an object containing the input to the workflow
    */
-  scheduleWorkflow(name: string, input: object, options?: { schedules?: Date[] }) {
+  scheduleWorkflow(name: string, options?: { schedules?: Date[]; input?: object }) {
     try {
+      let input: string | undefined;
+
+      if (options?.input) {
+        input = JSON.stringify(options.input);
+      }
+
       this.client.scheduleWorkflow({
         name,
         schedules: options?.schedules,
-        input: JSON.stringify(input),
+        input,
       });
     } catch (e: any) {
       throw new HatchetError(e.message);

--- a/src/clients/hatchet-client/hatchet-client.ts
+++ b/src/clients/hatchet-client/hatchet-client.ts
@@ -110,19 +110,19 @@ export class HatchetClient {
       channelFactory(this.config, this.credentials),
       clientFactory
     );
-    this.admin = new AdminClient(
-      this.config,
-      channelFactory(this.config, this.credentials),
-      clientFactory,
-      this.api,
-      this.tenantId
-    );
-
     this.listener = new ListenerClient(
       this.config,
       channelFactory(this.config, this.credentials),
       clientFactory,
       this.api
+    );
+    this.admin = new AdminClient(
+      this.config,
+      channelFactory(this.config, this.credentials),
+      clientFactory,
+      this.api,
+      this.tenantId,
+      this.listener
     );
 
     this.logger = new Logger('HatchetClient', this.config.log_level);

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,5 +5,6 @@ export * from './step';
 export * from './clients/worker';
 export * from './clients/rest';
 export * from './clients/admin';
+export * from './util/workflow-run-ref';
 
 export default Hatchet;

--- a/src/step.ts
+++ b/src/step.ts
@@ -22,9 +22,17 @@ export const CreateStepSchema = z.object({
   rate_limits: z.array(CreateRateLimitSchema).optional(),
 });
 
-type JSONPrimitive = string | number | boolean | null | Array<JSONPrimitive>;
+export type JsonObject = { [Key in string]: JsonValue } & {
+  [Key in string]?: JsonValue | undefined;
+};
 
-export type NextStep = { [key: string]: NextStep | JSONPrimitive | Array<NextStep> };
+export type JsonArray = JsonValue[] | readonly JsonValue[];
+
+export type JsonPrimitive = string | number | boolean | null;
+
+export type JsonValue = JsonPrimitive | JsonObject | JsonArray;
+
+export type NextStep = { [key: string]: JsonValue };
 
 interface ContextData<T, K> {
   input: T;
@@ -167,7 +175,7 @@ export class Context<T, K = {}> {
     await this.client.event.putStream(stepRunId, data);
   }
 
-  spawnWorkflow<Q = object, P = object>(
+  spawnWorkflow<Q = JsonValue, P = JsonValue>(
     workflowName: string,
     input: Q,
     key?: string

--- a/src/step.ts
+++ b/src/step.ts
@@ -7,7 +7,7 @@ import { LogLevel } from './clients/event/event-client';
 import { Logger } from './util/logger';
 import { parseJSON } from './util/parse';
 import { HatchetClient } from './clients/hatchet-client';
-import { WorkflowRunEvent, WorkflowRunEventType } from './protoc/dispatcher';
+import WorkflowRunRef from './util/workflow-run-ref';
 
 export const CreateRateLimitSchema = z.object({
   key: z.string(),
@@ -31,62 +31,6 @@ interface ContextData<T, K> {
   parents: Record<string, any>;
   triggered_by: string;
   user_data: K;
-}
-
-class ChildWorkflowRef<T> {
-  workflowRunId: Promise<string>;
-  parentWorkflowRunId: string;
-  client: HatchetClient;
-
-  constructor(workflowRunId: Promise<string>, parentWorkflowRunId: string, client: HatchetClient) {
-    this.workflowRunId = workflowRunId;
-    this.parentWorkflowRunId = parentWorkflowRunId;
-    this.client = client;
-  }
-
-  async stream(): Promise<AsyncGenerator<WorkflowRunEvent, void, unknown>> {
-    const workflowRunId = await this.workflowRunId;
-    const listener = await this.client.listener.getChildListener(
-      workflowRunId,
-      this.parentWorkflowRunId
-    );
-
-    return listener.stream();
-  }
-
-  async result(): Promise<T> {
-    const listener = await this.stream();
-
-    return new Promise<T>((resolve, reject) => {
-      (async () => {
-        for await (const event of await listener) {
-          if (event.eventType === WorkflowRunEventType.WORKFLOW_RUN_EVENT_TYPE_FINISHED) {
-            if (event.results.some((r) => !!r.error)) {
-              reject(event.results);
-              return;
-            }
-
-            const result = event.results.reduce(
-              (acc, r) => ({
-                ...acc,
-                [r.stepReadableId]: JSON.parse(r.output || '{}'),
-              }),
-              {} as T
-            );
-
-            resolve(result);
-            return;
-          }
-        }
-      })();
-    });
-  }
-
-  async toJSON(): Promise<string> {
-    return JSON.stringify({
-      workflowRunId: await this.workflowRunId,
-    });
-  }
 }
 
 export class Context<T, K = {}> {
@@ -227,21 +171,25 @@ export class Context<T, K = {}> {
     workflowName: string,
     input: Q,
     key?: string
-  ): ChildWorkflowRef<P> {
+  ): WorkflowRunRef<P> {
     const { workflowRunId, stepRunId } = this.action;
 
     const name = this.client.config.namespace + workflowName;
 
-    const childWorkflowRunIdPromise = this.client.admin.runWorkflow(name, input, {
-      parentId: workflowRunId,
-      parentStepRunId: stepRunId,
-      childKey: key,
-      childIndex: this.spawnIndex,
-    });
+    try {
+      const resp = this.client.admin.runWorkflow<P, Q>(name, input, {
+        parentId: workflowRunId,
+        parentStepRunId: stepRunId,
+        childKey: key,
+        childIndex: this.spawnIndex,
+      });
 
-    this.spawnIndex += 1;
+      this.spawnIndex += 1;
 
-    return new ChildWorkflowRef(childWorkflowRunIdPromise, workflowRunId, this.client);
+      return resp;
+    } catch (e: any) {
+      throw new HatchetError(e.message);
+    }
   }
 }
 

--- a/src/step.ts
+++ b/src/step.ts
@@ -167,7 +167,7 @@ export class Context<T, K = {}> {
     await this.client.event.putStream(stepRunId, data);
   }
 
-  spawnWorkflow<P = unknown, Q = unknown>(
+  spawnWorkflow<Q = object, P = object>(
     workflowName: string,
     input: Q,
     key?: string
@@ -177,7 +177,7 @@ export class Context<T, K = {}> {
     const name = this.client.config.namespace + workflowName;
 
     try {
-      const resp = this.client.admin.runWorkflow<P, Q>(name, input, {
+      const resp = this.client.admin.runWorkflow<Q, P>(name, input, {
         parentId: workflowRunId,
         parentStepRunId: stepRunId,
         childKey: key,

--- a/src/step.ts
+++ b/src/step.ts
@@ -89,7 +89,7 @@ class ChildWorkflowRef<T> {
   }
 }
 
-export class Context<T, K> {
+export class Context<T, K = {}> {
   data: ContextData<T, K>;
   input: T;
   controller = new AbortController();

--- a/src/util/workflow-run-ref.ts
+++ b/src/util/workflow-run-ref.ts
@@ -1,0 +1,88 @@
+import { ListenerClient, StepRunEvent } from '@hatchet/clients/listener/listener-client';
+import { WorkflowRunEventType } from '../protoc/dispatcher';
+
+type EventualWorkflowRunId =
+  | string
+  | Promise<string>
+  | Promise<{
+      workflowRunId: string;
+    }>;
+
+async function getWorkflowRunId(workflowRunId: EventualWorkflowRunId): Promise<string> {
+  if (typeof workflowRunId === 'string') {
+    return workflowRunId;
+  }
+
+  if (workflowRunId instanceof Promise) {
+    const resolved = await workflowRunId;
+    if (typeof resolved === 'string') {
+      return resolved;
+    }
+
+    return resolved.workflowRunId;
+  }
+
+  throw new Error('Invalid workflowRunId');
+}
+
+export default class WorkflowRunRef<T> {
+  workflowRunId: EventualWorkflowRunId;
+  parentWorkflowRunId?: string;
+  private client: ListenerClient;
+
+  constructor(
+    workflowRunId:
+      | string
+      | Promise<string>
+      | Promise<{
+          workflowRunId: string;
+        }>,
+    client: ListenerClient,
+    parentWorkflowRunId?: string
+  ) {
+    this.workflowRunId = workflowRunId;
+    this.parentWorkflowRunId = parentWorkflowRunId;
+    this.client = client;
+  }
+
+  async stream(): Promise<AsyncGenerator<StepRunEvent, void, unknown>> {
+    const workflowRunId = await getWorkflowRunId(this.workflowRunId);
+    return this.client.stream(workflowRunId);
+  }
+
+  async result(): Promise<T> {
+    const workflowRunId = await getWorkflowRunId(this.workflowRunId);
+
+    const streamable = await this.client.get(workflowRunId);
+
+    return new Promise<T>((resolve, reject) => {
+      (async () => {
+        for await (const event of streamable.stream()) {
+          if (event.eventType === WorkflowRunEventType.WORKFLOW_RUN_EVENT_TYPE_FINISHED) {
+            if (event.results.some((r) => !!r.error)) {
+              reject(event.results);
+              return;
+            }
+
+            const result = event.results.reduce(
+              (acc, r) => ({
+                ...acc,
+                [r.stepReadableId]: JSON.parse(r.output || '{}'),
+              }),
+              {} as T
+            );
+
+            resolve(result);
+            return;
+          }
+        }
+      })();
+    });
+  }
+
+  async toJSON(): Promise<string> {
+    return JSON.stringify({
+      workflowRunId: await this.workflowRunId,
+    });
+  }
+}

--- a/src/util/workflow-run-ref.ts
+++ b/src/util/workflow-run-ref.ts
@@ -45,6 +45,10 @@ export default class WorkflowRunRef<T> {
     this.client = client;
   }
 
+  async getWorkflowRunId(): Promise<string> {
+    return getWorkflowRunId(this.workflowRunId);
+  }
+
   async stream(): Promise<AsyncGenerator<StepRunEvent, void, unknown>> {
     const workflowRunId = await getWorkflowRunId(this.workflowRunId);
     return this.client.stream(workflowRunId);


### PR DESCRIPTION
This brings the TS SDK in line with the other SDKs, where we return a reference to a workflow run which has `stream` and `result` methods. 