### PR TITLE
fix broken link to typescript-sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Hatchet - Typescript SDK
 
-Please refer to the [Hatchet Typescript SDK documentation](https://docs.hatchet.run/sdks/typescript-sdk/setup) for setup instructions and usage details.
+Please refer to the [Hatchet Typescript SDK documentation](https://docs.hatchet.run/sdks/typescript-sdk) for setup instructions and usage details.


### PR DESCRIPTION
`/setup` was returning a 404