### PR TITLE
fix: prefix namespace to scheduled workflows

### DIFF
--- a/src/clients/admin/admin-client.ts
+++ b/src/clients/admin/admin-client.ts
@@ -297,7 +297,13 @@ export class AdminClient {
    * @param input an object containing the input to the workflow
    */
   scheduleWorkflow(name: string, options?: { schedules?: Date[]; input?: object }) {
+    let computedName = name;
+
     try {
+      if (this.config.namespace && !name.startsWith(this.config.namespace)) {
+        computedName = this.config.namespace + name;
+      }
+
       let input: string | undefined;
 
       if (options?.input) {
@@ -305,7 +311,7 @@ export class AdminClient {
       }
 
       this.client.scheduleWorkflow({
-        name,
+        name: computedName,
         schedules: options?.schedules,
         input,
       });


### PR DESCRIPTION
This namespaces the scheduled workflows when the hatchet client has been configured with a namespace. This allows them to find the namespaced workers.

example from the UI where the namespace is missing from the workflow:
<img width="1002" alt="image" src="https://github.com/user-attachments/assets/1e600581-dadd-4829-8f82-3efc2f5ae587">

Note: I couldn't run or build locally so was unable to run tests.