### PR TITLE
Typescript Example Delimeters

### DIFF
--- a/src/examples/affinity-workers.ts
+++ b/src/examples/affinity-workers.ts
@@ -1,9 +1,10 @@
+//Typescript
 import { WorkerLabelComparator } from '@hatchet/protoc/workflows';
 import Hatchet from '../sdk';
 import { Workflow } from '../workflow';
 
 const hatchet = Hatchet.init();
-
+//START specifying-step-desired-labels
 const workflow: Workflow = {
   id: 'affinity-workflow',
   description: 'test',
@@ -25,7 +26,8 @@ const workflow: Workflow = {
     },
   ],
 };
-
+//END specifying-step-desired-labels
+//START specifying-step-desired-labels
 const childWorkflow: Workflow = {
   id: 'child-affinity-workflow',
   description: 'test',
@@ -59,14 +61,16 @@ const childWorkflow: Workflow = {
     },
   ],
 };
-
+//END specifying-step-desired-labels
 async function main() {
+  //START specifying-worker-labels
   const worker1 = await hatchet.worker('affinity-worker-1', {
     labels: {
       model: 'abc',
       memory: 1024,
     },
   });
+  //END specifying-worker-labels
   await worker1.registerWorkflow(workflow);
   await worker1.registerWorkflow(childWorkflow);
   worker1.start();

--- a/src/examples/concurrency/cancel-in-progress/concurrency-worker.ts
+++ b/src/examples/concurrency/cancel-in-progress/concurrency-worker.ts
@@ -1,3 +1,4 @@
+//Typescript
 import Hatchet from '../../../sdk';
 import { Workflow } from '../../../workflow';
 
@@ -7,7 +8,7 @@ const sleep = (ms: number) =>
   new Promise((resolve) => {
     setTimeout(resolve, ms);
   });
-
+//START concurrency_cancel_in_progress
 const workflow: Workflow = {
   id: 'concurrency-example',
   description: 'test',
@@ -50,6 +51,7 @@ const workflow: Workflow = {
     },
   ],
 };
+//END concurrency_cancel_in_progress
 
 async function main() {
   const worker = await hatchet.worker('example-worker');

--- a/src/examples/concurrency/group-round-robin/concurrency-worker.ts
+++ b/src/examples/concurrency/group-round-robin/concurrency-worker.ts
@@ -9,6 +9,7 @@ const sleep = (ms: number) =>
     setTimeout(resolve, ms);
   });
 
+//START concurrency_group_red_robin
 const workflow: Workflow = {
   id: 'concurrency-example-rr',
   description: 'test',
@@ -45,6 +46,7 @@ const workflow: Workflow = {
     },
   ],
 };
+//END concurrency_group_red_robin
 
 async function main() {
   //START setting-concurrency-on-workers

--- a/src/examples/concurrency/group-round-robin/concurrency-worker.ts
+++ b/src/examples/concurrency/group-round-robin/concurrency-worker.ts
@@ -1,3 +1,4 @@
+//Typescript
 import Hatchet from '../../../sdk';
 import { ConcurrencyLimitStrategy, Workflow } from '../../../workflow';
 
@@ -46,7 +47,9 @@ const workflow: Workflow = {
 };
 
 async function main() {
+  //START setting-concurrency-on-workers
   const worker = await hatchet.worker('example-worker');
+  //END setting-concurrency-on-workers
   await worker.registerWorkflow(workflow);
   worker.start();
 }

--- a/src/examples/manual-trigger.ts
+++ b/src/examples/manual-trigger.ts
@@ -1,7 +1,9 @@
+//Typescript
 import Hatchet from '../sdk';
 
 const hatchet = Hatchet.init();
 
+//START listeners
 async function main() {
   const workflowRun = hatchet.admin.runWorkflow('simple-workflow', {});
   const stream = await workflowRun.stream();
@@ -10,5 +12,6 @@ async function main() {
     console.log('event received', event);
   }
 }
+//END listeners
 
 main();

--- a/src/examples/on-failure.ts
+++ b/src/examples/on-failure.ts
@@ -1,3 +1,4 @@
+//Typescript
 import Hatchet from '../sdk';
 import { Workflow } from '../workflow';
 
@@ -9,7 +10,7 @@ const sleep = (ms: number) =>
   new Promise((resolve) => {
     setTimeout(resolve, ms);
   });
-
+//START defining-an-on-failure-step
 const workflow: Workflow = {
   id: 'on-failure-example',
   description: 'test',
@@ -34,6 +35,7 @@ const workflow: Workflow = {
     },
   },
 };
+//END defining-an-on-failure-step
 
 async function main() {
   const worker = await hatchet.worker('example-worker', 1);

--- a/src/examples/rate-limit/worker.ts
+++ b/src/examples/rate-limit/worker.ts
@@ -1,9 +1,10 @@
+//Typescript
 import { RateLimitDuration } from '../../protoc/workflows';
 import Hatchet from '../../sdk';
 import { Workflow } from '../../workflow';
 
 const hatchet = Hatchet.init();
-
+//START consuming-rate-limits
 const workflow: Workflow = {
   id: 'rate-limit-workflow',
   description: 'test',
@@ -21,9 +22,12 @@ const workflow: Workflow = {
     },
   ],
 };
+//END consuming-rate-limits
 
 async function main() {
+  //START declaring-global-limits
   await hatchet.admin.putRateLimit('test-limit', 1, RateLimitDuration.MINUTE);
+  //END declaring-global-limits
   const worker = await hatchet.worker('example-worker');
   await worker.registerWorkflow(workflow);
   worker.start();

--- a/src/examples/simple-worker.ts
+++ b/src/examples/simple-worker.ts
@@ -9,6 +9,7 @@ const sleep = (ms: number) =>
     setTimeout(resolve, ms);
   });
 
+//START how-to-use-step-level-retries
 const workflow: Workflow = {
   id: 'simple-workflow',
   description: 'test',
@@ -37,6 +38,7 @@ const workflow: Workflow = {
     },
   ],
 };
+//END how-to-use-step-level-retries
 //START registering_workflows_starting_workers
 async function main() {
   const worker = await hatchet.worker('example-worker');

--- a/src/examples/simple-worker.ts
+++ b/src/examples/simple-worker.ts
@@ -1,3 +1,4 @@
+//Typescript
 import Hatchet from '../sdk';
 import { Workflow } from '../workflow';
 
@@ -36,11 +37,11 @@ const workflow: Workflow = {
     },
   ],
 };
-
+//START registering_workflows_starting_workers
 async function main() {
   const worker = await hatchet.worker('example-worker');
   await worker.registerWorkflow(workflow);
   worker.start();
 }
-
+//END registering_workflows_starting_workers
 main();

--- a/src/examples/sticky-worker.ts
+++ b/src/examples/sticky-worker.ts
@@ -1,8 +1,9 @@
+//Typescript
 import Hatchet from '../sdk';
 import { StickyStrategy, Workflow } from '../workflow';
 
 const hatchet = Hatchet.init();
-
+//START setting-sticky-assignment
 const workflow: Workflow = {
   id: 'sticky-workflow',
   description: 'test',
@@ -25,7 +26,9 @@ const workflow: Workflow = {
     },
   ],
 };
+//END setting-sticky-assignment
 
+//START sticky-child-workflows
 const childWorkflow: Workflow = {
   id: 'child-sticky-workflow',
   description: 'test',
@@ -50,6 +53,7 @@ const childWorkflow: Workflow = {
     },
   ],
 };
+//END sticky-child-workflows
 
 async function main() {
   const worker1 = await hatchet.worker('sticky-worker-1');

--- a/src/examples/stream-by-additional-meta.ts
+++ b/src/examples/stream-by-additional-meta.ts
@@ -1,7 +1,9 @@
+//Typescript
 import Hatchet from '../sdk';
 
 const hatchet = Hatchet.init();
 
+//START streaming-by-additional-metadata
 async function main() {
   // Generate a random stream key to use to track all
   // stream events for this workflow run.
@@ -26,5 +28,6 @@ async function main() {
     console.log('event received', event);
   }
 }
+//END streaming-by-additional-metadata
 
 main();


### PR DESCRIPTION
Adding delimiters to the Typescript examples. We used our best judgement to set these delimeters. In some cases, these code blocks are not 1:1 to the examples in the docs (and in others, they can not be found at all in the examples folder).

Delimeters include:
- `//Typescript` at the front of the file.
- `//START (codeblock name)` at the start of the code block.
- `//END (codeblock name)` at the end of the code block.

Codeblock names should be unique within a language.