### PR TITLE
add return statement to putWorkflow api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ openapi.yaml
 
 .gitmodules
 /hatchet
+
+.idea

--- a/src/clients/admin/admin-client.ts
+++ b/src/clients/admin/admin-client.ts
@@ -80,7 +80,7 @@ export class AdminClient {
    */
   async putWorkflow(workflow: CreateWorkflowVersionOpts) {
     try {
-      await retrier(async () => this.client.putWorkflow({ opts: workflow }), this.logger);
+      return await retrier(async () => this.client.putWorkflow({ opts: workflow }), this.logger);
     } catch (e: any) {
       throw new HatchetError(e.message);
     }

--- a/src/clients/worker/worker.test.ts
+++ b/src/clients/worker/worker.test.ts
@@ -55,7 +55,14 @@ describe('Worker', () => {
   describe('registerWorkflow', () => {
     it('should update the registry', async () => {
       const worker = new Worker(hatchet, { name: 'WORKER_NAME' });
-      const putWorkflowSpy = jest.spyOn(worker.client.admin, 'putWorkflow').mockResolvedValue();
+      const putWorkflowSpy = jest.spyOn(worker.client.admin, 'putWorkflow').mockResolvedValue({
+        id: 'workflow1',
+        version: 'v0.1.0',
+        order: 1,
+        workflowId: 'workflow1',
+        createdAt: undefined,
+        updatedAt: undefined,
+      });
 
       const workflow = {
         id: 'workflow1',
@@ -86,8 +93,6 @@ describe('Worker', () => {
   describe('handle_start_step_run', () => {
     it('should start a step run', async () => {
       const worker = new Worker(hatchet, { name: 'WORKER_NAME' });
-
-      const putWorkflowSpy = jest.spyOn(worker.client.admin, 'putWorkflow').mockResolvedValue();
 
       const getActionEventSpy = jest.spyOn(worker, 'getStepActionEvent');
 


### PR DESCRIPTION
Currently, putWorkflow does not return anything, which makes it impossible to delete or get the workflow created via API. 

With this fix, putWorkflow will return the workflow object with the id, version, name etc.