### PR TITLE
fix: make invalid workflowRunId error more descriptive

### DIFF
--- a/src/util/workflow-run-ref.ts
+++ b/src/util/workflow-run-ref.ts
@@ -35,11 +35,11 @@ async function getWorkflowRunId(workflowRunId: EventualWorkflowRunId): Promise<s
         throw new DedupeViolationErr(e.details);
       }
 
-      throw new Error('Invalid workflowRunId');
+      throw e;
     }
   }
 
-  throw new Error('Invalid workflowRunId');
+  throw new Error('Invalid workflowRunId: must be a string or a promise');
 }
 
 export default class WorkflowRunRef<T> {


### PR DESCRIPTION
Currently we throw `invalid workflowRunId` which swallows an underlying gRPC error when the client can't connect. 